### PR TITLE
Allow the IPython command line to run *.ipynb files .

### DIFF
--- a/IPython/core/shellapp.py
+++ b/IPython/core/shellapp.py
@@ -312,7 +312,7 @@ class InteractiveShellApp(Configurable):
                 # behavior.
                 with preserve_keys(self.shell.user_ns, '__file__'):
                     self.shell.user_ns['__file__'] = fname
-                    if full_filename.endswith('.ipy'):
+                    if full_filename.endswith('.ipy') or full_filename.endswith('.ipynb'):
                         self.shell.safe_execfile_ipy(full_filename,
                                                      shell_futures=shell_futures)
                     else:


### PR DESCRIPTION
This PR allows `_exec_file` in the shell app to pass __ipynb__ files to `safe_execfile_ipy` in the `interactiveshell`.  `safe_execfile_ipy` already has the machinery to consume notebooks.